### PR TITLE
changing row description to be optional

### DIFF
--- a/src/messages/interactive.js
+++ b/src/messages/interactive.js
@@ -295,7 +295,7 @@ class Row {
         if (title.length > 24)
             throw new Error("Row title must be 24 characters or less");
         // Yours truly, JScheck.
-        if (!description?.length || description.length > 72)
+        if (description || description.length > 72)
             throw new Error("Row description must be 72 characters or less");
 
         this.id = id;


### PR DESCRIPTION
The validation done to the row description length was checking for the existence of the length property and not only the existence of the "description" itself. So if I sent an empty description, it doesn't get validated, same if I didn't send it at all.