### PR TITLE
Server agnostic recreation of EventsEmmiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ import { fetch } from "undici";
 const Whatsapp = new WhatsAppAPI({
     token: "YOUR_TOKEN_HERE",
     appSecret: "YOUR_SECRET_HERE",
-    ponyfill: fetch
+    ponyfill: {
+        fetch
+    }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ function post(e) {
     return Whatsapp.post(JSON.parse(e.data));
 }
 
-Whatsapp.on("message", ({ phoneID, from, message, name, raw }) => {
+Whatsapp.on.message = ({ phoneID, from, message, name, raw }) => {
     console.log(`User ${name} (${from}) sent to bot ${phoneID} ${JSON.stringify(message)}`);
 
     let promise;
@@ -84,11 +84,11 @@ Whatsapp.on("message", ({ phoneID, from, message, name, raw }) => {
     console.log(await promise ?? "There are more types of messages, such as locations, templates, interactives, reactions and all the other media types.");
     
     Whatsapp.markAsRead(phoneID, message.id);
-});
+};
 
-Whatsapp.on("sent", ({ phoneID, to, message, raw }) => {
+Whatsapp.on.sent = ({ phoneID, to, message, raw }) => {
     console.log(`Bot ${phoneID} sent to user ${to} ${message}\n\n${JSON.stringify(raw)}`);
-});
+};
 ```
 
 To recieve the post requests on message, you must setup the webhook at your Facebook app.

--- a/test/index.test.cjs
+++ b/test/index.test.cjs
@@ -256,7 +256,7 @@ describe("WhatsAppAPI", function () {
         it("should run the logger after sending a message", async function () {
             const spy = sinon_spy();
 
-            Whatsapp.on("sent", spy);
+            Whatsapp.on.sent = spy;
 
             clientFacebook
                 .intercept({
@@ -288,7 +288,7 @@ describe("WhatsAppAPI", function () {
         it("should handle failed deliveries responses", async function () {
             const spy = sinon_spy();
 
-            Whatsapp.on("sent", spy);
+            Whatsapp.on.sent = spy;
 
             const unexpectedResponse = {
                 error: {
@@ -331,7 +331,7 @@ describe("WhatsAppAPI", function () {
 
             const spy = sinon_spy();
 
-            Whatsapp.on("sent", spy);
+            Whatsapp.on.sent = spy;
 
             Whatsapp.sendMessage(bot, user, message);
 
@@ -1652,7 +1652,7 @@ describe("WhatsAppAPI", function () {
                 let spy_on_message;
                 this.beforeEach(function () {
                     spy_on_message = sinon_spy();
-                    Whatsapp.on("message", spy_on_message);
+                    Whatsapp.on.message = spy_on_message;
                 });
 
                 this.beforeEach(function () {
@@ -1696,7 +1696,7 @@ describe("WhatsAppAPI", function () {
                 let spy_on_status;
                 this.beforeEach(function () {
                     spy_on_status = sinon_spy();
-                    Whatsapp.on("status", spy_on_status);
+                    Whatsapp.on.status = spy_on_status;
                 });
 
                 this.beforeEach(function () {


### PR DESCRIPTION
No one said it would be pretty, although I like it more than on("string", ...) syntax.

The only lost feature is multi callbacks support, which could have been a nice feature, but not really the intended way to use the library.

However, I think this provides an aditional type check for the callbacks to match the valid arguments.