### PR TITLE
CommonJS build process improve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,11 +115,7 @@ docs_temp/
 docs/
 
 # Builds
-lib/*
-!lib/common/
-
-lib/common/*
-!lib/common/package.json
+lib/
 
 # JetBrains IDEs
 .idea

--- a/lib/common/package.json
+++ b/lib/common/package.json
@@ -1,3 +1,0 @@
-{
-    "type": "commonjs"
-}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:module": "tsc",
     "build:module:watch": "tsc --watch",
     "build:module:types": "tsc -d",
-    "build:common": "tsc -p tsconfig.common.json",
+    "build:common": "tsc -p tsconfig.common.json && echo {\"type\": \"commonjs\"} > ./lib/common/package.json",
     "build:common:watch": "tsc -p tsconfig.common.json --watch",
     "build:common:types": "tsc -p tsconfig.common.json -d",
     "build:types": "tsc -p tsconfig.types.json",


### PR DESCRIPTION
Rather than keeping the package.json, write it on build time