### PR TITLE
Removed use of internal Text

### DIFF
--- a/src/messages/interactive.ts
+++ b/src/messages/interactive.ts
@@ -5,7 +5,6 @@ import type {
 } from "../types.js";
 import type { AtLeastOne } from "../utils.js";
 
-import type Text from "./text.js";
 import type { Document, Image, Video } from "./media.js";
 
 /**
@@ -52,7 +51,7 @@ export class Interactive implements ClientMessage {
      * @param footer - The footer component of the interactive message
      * @throws If body is not provided, unless action is an ActionCatalog with a single product
      * @throws If header is provided for an ActionCatalog with a single product
-     * @throws If header of type Text is not provided for an ActionCatalog with a product list
+     * @throws If header of type text is not provided for an ActionCatalog with a product list
      * @throws If header is not of type text, unless action is an ActionButtons
      */
     constructor(
@@ -73,10 +72,10 @@ export class Interactive implements ClientMessage {
             );
         if (action._type === "product_list" && header?.type !== "text")
             throw new Error(
-                "Interactive must have a Text header component if action is a product list"
+                "Interactive must have a text header component if action is a product list"
             );
         if (header && action._type !== "button" && header?.type !== "text")
-            throw new Error("Interactive header must be of type Text");
+            throw new Error("Interactive header must be of type text");
 
         this.type = action._type;
 
@@ -150,7 +149,7 @@ export class Header {
     /**
      * The type of the header
      */
-    readonly type: "text" | "video" | "image" | "document";
+    readonly type: "text" | "image" | "video" | "document";
     /**
      * The text of the parameter
      */
@@ -172,27 +171,25 @@ export class Header {
      * Builds a header component for an Interactive message
      *
      * @param object - The message object for the header
-     * @throws If object is not a Document, Image, Text, or Video
-     * @throws If object is a Text and is over 60 characters
+     * @throws If object is a string and is over 60 characters
      * @throws If object is a Media and has a caption
      */
-    constructor(object: Document | Image | Text | Video) {
-        this.type = object._type;
-
+    constructor(object: Document | Image | Video | string) {
         // All interactive's header can go to hell with its "exceptions"
-        if (object._type === "text") {
-            if (object.body.length > 60)
+        if (typeof object === "string") {
+            if (object.length > 60)
                 throw new Error("Header text must be 60 characters or less");
 
-            this[object._type] = object.body;
+            this.type = "text";
         } else {
+            this.type = object._type;
             if ("caption" in object)
                 throw new Error(`Header ${this.type} must not have a caption`);
-
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore - TS dumb, the _type will always match the message type
-            this[this.type as "video" | "image" | "document"] = object;
         }
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - TS dumb, the _type will always match the message type
+        this[this.type] = object;
     }
 }
 

--- a/src/messages/template.ts
+++ b/src/messages/template.ts
@@ -6,7 +6,6 @@ import type {
 } from "../types.js";
 import { AtLeastOne } from "../utils.js";
 
-import type Text from "./text.js";
 import type Location from "./location.js";
 import type { Document, Image, Video } from "./media.js";
 
@@ -343,17 +342,17 @@ export class HeaderParameter {
 
     /**
      * Builds a parameter object for a HeaderComponent.
-     * For Text parameter, the character limit is 60.
+     * For text parameter, the character limit is 60.
      * For Document parameter, only PDF documents are supported for document-based message templates (not checked).
      * For Location parameter, the location must have a name and address.
      *
      * @param parameter - The parameter to be used in the template's header
-     * @throws If parameter is a Text and it's over 60 characters
+     * @throws If parameter is a string and it's over 60 characters
      * @throws If parameter is a Location and it doesn't have a name and address
      */
     constructor(
         parameter:
-            | Text
+            | string
             | Currency
             | DateTime
             | Image
@@ -361,16 +360,11 @@ export class HeaderParameter {
             | Video
             | Location
     ) {
-        this.type = parameter._type;
-
-        // Text type can go to hell
-        if (parameter._type === "text") {
-            if (parameter.body.length > 60)
+        if (typeof parameter === "string") {
+            if (parameter.length > 60)
                 throw new Error("Header text must be 60 characters or less");
 
-            Object.defineProperty(this, this.type, {
-                value: parameter.body
-            });
+            this.type = "text";
         } else {
             if (
                 parameter._type === "location" &&
@@ -379,10 +373,12 @@ export class HeaderParameter {
                 throw new Error("Header location must have a name and address");
             }
 
-            Object.defineProperty(this, this.type, {
-                value: parameter
-            });
+            this.type = parameter._type;
         }
+
+        Object.defineProperty(this, this.type, {
+            value: parameter
+        });
     }
 }
 
@@ -452,31 +448,28 @@ export class BodyParameter {
 
     /**
      * Builds a parameter object for a BodyComponent.
-     * For Text parameter, the character limit is 32768 if only one BodyComponent is used for the Template, else it's 1024.
+     * For text parameter, the character limit is 32768 if only one BodyComponent is used for the Template, else it's 1024.
      *
      * @param parameter - The parameter to be used in the template
-     * @throws If parameter is a Text and it's over 32768 characters
-     * @throws If parameter is a Text, there are other components in the Template and it's over 1024 characters
+     * @throws If parameter is a string and it's over 32768 characters
+     * @throws If parameter is a string, there are other components in the Template and it's over 1024 characters
      * @see BodyComponent._build The method that checks the 1024 character limit
      */
-    constructor(parameter: Text | Currency | DateTime) {
-        this.type = parameter._type;
-
-        // Text type can go to hell
-        if (parameter._type === "text") {
-            // We check the upper limit of the text length here
-            // And if a shorter string is needed,
-            // Check and throw an error on the build method of BodyComponent
-            if (parameter.body.length > 32_768)
+    constructor(parameter: string | Currency | DateTime) {
+        if (typeof parameter === "string") {
+            // Check the upper limit of the string length here
+            // If a shorter one is needed, check and throw an
+            // error on the build method of BodyComponent
+            if (parameter.length > 32_768)
                 throw new Error("Body text must be 32768 characters or less");
 
-            Object.defineProperty(this, this.type, {
-                value: parameter.body
-            });
+            this.type = "text";
         } else {
-            Object.defineProperty(this, this.type, {
-                value: parameter
-            });
+            this.type = parameter._type;
         }
+
+        Object.defineProperty(this, this.type, {
+            value: parameter
+        });
     }
 }

--- a/src/messages/text.ts
+++ b/src/messages/text.ts
@@ -28,7 +28,6 @@ export default class Text implements ClientMessage {
      * @throws If body is over 4096 characters
      */
     constructor(body: string, preview_url?: boolean) {
-        // This will definitely bring issues in the future :/
         if (body.length > 4096)
             throw new Error("Text body must be less than 4096 characters");
         this.body = body;


### PR DESCRIPTION
Text was never meant to be used in other objects, but the docs used to say text were a Text object.

Now they updated most of the types of text to string, so it's safe to just ask for a string in our classes too.