### PR TITLE
Going for less _generic_ types

### DIFF
--- a/src/messages/contacts.ts
+++ b/src/messages/contacts.ts
@@ -9,9 +9,6 @@ export type BuiltContact = {
     phones?: Phone[];
     emails?: Email[];
     urls?: Url[];
-    // Allow the user create custom components
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key: string]: any;
 };
 
 /**
@@ -55,17 +52,12 @@ export class Contacts implements ClientMessage {
             const contact = {} as BuiltContact;
 
             for (const component of components) {
-                const name = component._type;
+                const name = component._type as keyof typeof contact;
 
                 if (component._many) {
                     if (!(name in contact)) {
                         Object.defineProperty(contact, name, {
-                            value: [] as
-                                | Address[]
-                                | Email[]
-                                | Phone[]
-                                | Url[]
-                                | ContactComponent[]
+                            value: [] as Address[] | Email[] | Phone[] | Url[]
                         });
                     }
 

--- a/src/messages/interactive.ts
+++ b/src/messages/interactive.ts
@@ -1,8 +1,4 @@
-import type {
-    ClientMessage,
-    ClientMessageComponent,
-    ClientTypedMessageComponent
-} from "../types.js";
+import type { ClientMessage, ClientTypedMessageComponent } from "../types.js";
 import type { AtLeastOne } from "../utils.js";
 
 import type { Document, Image, Video } from "./media.js";
@@ -28,15 +24,15 @@ export class Interactive implements ClientMessage {
     /**
      * The body component of the interactive message
      */
-    readonly body?: Body | ClientMessageComponent;
+    readonly body?: Body;
     /**
      * The header component of the interactive message
      */
-    readonly header?: Header | ClientMessageComponent;
+    readonly header?: Header;
     /**
      * The footer component of the interactive message
      */
-    readonly footer?: Footer | ClientMessageComponent;
+    readonly footer?: Footer;
 
     get _type(): "interactive" {
         return "interactive";

--- a/src/messages/template.ts
+++ b/src/messages/template.ts
@@ -1,6 +1,5 @@
 import type {
     ClientMessage,
-    ClientMessageComponent,
     ClientBuildableMessageComponent,
     ClientTypedMessageComponent
 } from "../types.js";
@@ -29,7 +28,7 @@ export class Template implements ClientMessage {
     /**
      * The language of the template
      */
-    readonly language: Language | ClientMessageComponent;
+    readonly language: Language;
     /**
      * The components of the template
      */
@@ -37,7 +36,6 @@ export class Template implements ClientMessage {
         | HeaderComponent
         | BodyComponent
         | BuiltButtonComponent
-        | ClientMessageComponent
     )[];
 
     get _type(): "template" {
@@ -55,13 +53,8 @@ export class Template implements ClientMessage {
      */
     constructor(
         name: string,
-        language: string | Language | ClientMessageComponent,
-        ...components: (
-            | HeaderComponent
-            | BodyComponent
-            | ButtonComponent
-            | ClientBuildableMessageComponent
-        )[]
+        language: string | Language,
+        ...components: (HeaderComponent | BodyComponent | ButtonComponent)[]
     ) {
         this.name = name;
         this.language =
@@ -387,7 +380,7 @@ export class HeaderParameter {
  *
  * @group Template
  */
-export class BodyComponent {
+export class BodyComponent implements ClientBuildableMessageComponent {
     /**
      * The type of the component
      */

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -152,10 +152,8 @@ export interface ClientMessage {
      * The message type
      *
      * @internal
-     * @privateRemarks The built-in classes will return values within {@link ClientMessageNames},
-     * however, in order to allow custom messages, it's defined as a string.
      */
-    get _type(): ClientMessageNames | string;
+    get _type(): ClientMessageNames;
     /**
      * The message built as a string. In most cases it's just JSON.stringify(this)
      *
@@ -164,13 +162,7 @@ export interface ClientMessage {
     _build(): string;
 }
 
-export interface ClientMessageComponent {
-    // Allow the user create custom components
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key: string]: any;
-}
-
-export interface ClientTypedMessageComponent extends ClientMessageComponent {
+export interface ClientTypedMessageComponent {
     /**
      * The message's component type
      *
@@ -179,8 +171,7 @@ export interface ClientTypedMessageComponent extends ClientMessageComponent {
     get _type(): string;
 }
 
-export interface ClientBuildableMessageComponent
-    extends ClientMessageComponent {
+export interface ClientBuildableMessageComponent {
     /**
      * The message's component builder method
      *
@@ -294,10 +285,6 @@ export type ClientMessageRequest =
           | {
                 type: "reaction";
                 reaction?: string;
-            }
-          | {
-                type: string;
-                [key: string]: string;
             }
       );
 


### PR DESCRIPTION
I thought making some types less generic would be good to support future updates and let the final user customize everything, but the fact that ts-ignore exists turns all of it pointless.

Plus, ClientMessageComponent was used really inconsistent, so I'm happy to remove it.