### PR TITLE
Exports fix

### DIFF
--- a/build.js
+++ b/build.js
@@ -19,6 +19,7 @@ const sharedConfig = {
 // ESM
 await build({
     ...sharedConfig,
+    format: "esm",
     outdir: "lib/esm"
 });
 

--- a/package.json
+++ b/package.json
@@ -23,9 +23,17 @@
       "import": "./lib/esm/messages/index.js",
       "require": "./lib/cjs/messages/index.js"
     },
-    "./*": {
-      "import": "./lib/esm/*.js",
-      "require": "./lib/cjs/*.js"
+    "./setup/*": {
+      "import": "./lib/esm/setup/*.js",
+      "require": "./lib/cjs/setup/*.js"
+    },
+    "./emitters": {
+      "import": "./lib/esm/emitters.d.ts",
+      "require": "./lib/cjs/emitters.d.ts"
+    },
+    "./types": {
+      "import": "./lib/esm/types.js",
+      "require": "./lib/cjs/types.js"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
       "require": "./lib/cjs/messages/*.js"
     },
     "./setup": null,
+    "./setup/index": null,
     "./setup/*": {
       "types": "./lib/types/setup/*.d.ts",
       "import": "./lib/esm/setup/*.js",
@@ -59,6 +60,7 @@
       "messages/*": [
         "lib/types/messages/*.d.ts"
       ],
+      "setup/index": [],
       "setup/*": [
         "lib/types/setup/*.d.ts"
       ],

--- a/package.json
+++ b/package.json
@@ -11,30 +11,27 @@
   "files": [
     "lib/**/*"
   ],
-  "types": "lib/types/index.d.ts",
+  "types": "lib/esm/index.d.ts",
   "module": "lib/esm/index.js",
   "main": "lib/cjs/index.js",
   "exports": {
     ".": {
-      "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.js"
     },
     "./messages": {
-      "types": "./lib/types/messages/index.d.ts",
       "import": "./lib/esm/messages/index.js",
       "require": "./lib/cjs/messages/index.js"
     },
     "./setup/*": {
-      "types": "./lib/types/setup/*.d.ts",
       "import": "./lib/esm/setup/*.js",
       "require": "./lib/cjs/setup/*.js"
     },
     "./emitters": {
-      "types": "./lib/types/emitters.d.ts"
+      "import": "./lib/esm/emitters.d.ts",
+      "require": "./lib/cjs/emitters.d.ts"
     },
     "./types": {
-      "types": "./lib/types/types.d.ts",
       "import": "./lib/esm/types.js",
       "require": "./lib/cjs/types.js"
     }
@@ -42,7 +39,9 @@
   "scripts": {
     "build": "npm run build:code && npm run build:types",
     "build:code": "node -r dotenv/config build.js",
-    "build:types": "tsc && cp ./src/*.d.ts ./lib/types",
+    "build:types": "npm run build:types:esm && npm run build:types:cjs",
+    "build:types:esm": "tsc --outDir ./lib/esm && cp ./src/*.d.ts ./lib/esm",
+    "build:types:cjs": "tsc --outDir ./lib/cjs && cp ./src/*.d.ts ./lib/cjs",
     "test": "mocha",
     "test:build": "npm run build && npm run test",
     "test:watch": "mocha --reporter min --watch",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,31 @@
       "require": "./lib/cjs/types.js"
     }
   },
+  "//": "https://github.com/andrewbranch/example-subpath-exports-ts-compat/blob/main/examples/node_modules/types-versions-wildcards/package.json",
+  "//": "Without this, IntelliSense will throw an error when importing subpaths ONLY on JS files, although it does run fine with Node.",
+  "//": "Even more stunishing: if included, IntelliSense works even BETTER than with TS.",
+  "typesVersions": {
+    "*": {
+      ".": [
+        "lib/types/index.d.ts"
+      ],
+      "messages": [
+        "lib/types/messages/index.d.ts"
+      ],
+      "messages/*": [
+        "lib/types/messages/*.d.ts"
+      ],
+      "setup/*": [
+        "lib/types/setup/*.d.ts"
+      ],
+      "emitters": [
+        "lib/types/emitters.d.ts"
+      ],
+      "types": [
+        "lib/types/types.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "build": "npm run build:code && npm run build:types",
     "build:code": "node -r dotenv/config build.js",

--- a/package.json
+++ b/package.json
@@ -11,27 +11,30 @@
   "files": [
     "lib/**/*"
   ],
-  "types": "lib/esm/index.d.ts",
+  "types": "lib/types/index.d.ts",
   "module": "lib/esm/index.js",
   "main": "lib/cjs/index.js",
   "exports": {
     ".": {
+      "types": "./lib/types/index.d.ts",
       "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.js"
     },
     "./messages": {
+      "types": "./lib/types/messages/index.d.ts",
       "import": "./lib/esm/messages/index.js",
       "require": "./lib/cjs/messages/index.js"
     },
     "./setup/*": {
+      "types": "./lib/types/setup/*.d.ts",
       "import": "./lib/esm/setup/*.js",
       "require": "./lib/cjs/setup/*.js"
     },
     "./emitters": {
-      "import": "./lib/esm/emitters.d.ts",
-      "require": "./lib/cjs/emitters.d.ts"
+      "types": "./lib/types/emitters.d.ts"
     },
     "./types": {
+      "types": "./lib/types/types.d.ts",
       "import": "./lib/esm/types.js",
       "require": "./lib/cjs/types.js"
     }
@@ -39,9 +42,7 @@
   "scripts": {
     "build": "npm run build:code && npm run build:types",
     "build:code": "node -r dotenv/config build.js",
-    "build:types": "npm run build:types:esm && npm run build:types:cjs",
-    "build:types:esm": "tsc --outDir ./lib/esm && cp ./src/*.d.ts ./lib/esm",
-    "build:types:cjs": "tsc --outDir ./lib/cjs && cp ./src/*.d.ts ./lib/cjs",
+    "build:types": "tsc && cp ./src/*.d.ts ./lib/types",
     "test": "mocha",
     "test:build": "npm run build && npm run test",
     "test:watch": "mocha --reporter min --watch",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
       "import": "./lib/esm/messages/index.js",
       "require": "./lib/cjs/messages/index.js"
     },
+    "./messages/*": {
+      "types": "./lib/types/messages/*.d.ts",
+      "import": "./lib/esm/messages/*.js",
+      "require": "./lib/cjs/messages/*.js"
+    },
+    "./setup": null,
     "./setup/*": {
       "types": "./lib/types/setup/*.d.ts",
       "import": "./lib/esm/setup/*.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "include": ["src/**/*"],
   "compilerOptions": {
     "lib": ["ESNext"],
+    "outDir": "lib/types",
     "types": ["node", "undici"],
     "declaration": true,
     "declarationMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "include": ["src/**/*"],
   "compilerOptions": {
-    "lib": ["ESNext"],                                   /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    "types": ["node", "undici"],                         /* Specify type package names to be included without being referenced in a source file. */
-    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    "declarationMap": true,                              /* Create sourcemaps for d.ts files. */
-    "emitDeclarationOnly": true,                         /* Only output d.ts files and not JavaScript files. */
-    "isolatedModules": true,                             /* Ensure that each file can be safely transpiled without relying on other imports. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "lib": ["ESNext"],
+    "types": ["node", "undici"],
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "include": ["src/**/*"],
   "compilerOptions": {
     "lib": ["ESNext"],
-    "outDir": "lib/types",
     "types": ["node", "undici"],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Lesson learnt: exports property is for TS, and typesVersions is for VS Code IntelliSense for JS.

Also, if possible, avoid at all cost using * in any of them, as it will most likely fail catastrophically.

Fixes the main import needing /index (I hope) (#157)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `npm run test` and lint the project with `npm run lint` and `npm run prettier`
