### PR TITLE
Added reply method to OnMessage callback

### DIFF
--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -203,8 +203,8 @@ const Whatsapp = new WhatsAppAPI({
     }
 });
 
-Whatsapp.on.message = ({ phoneID, from, name }) => {
-    Whatsapp.sendMessage(phoneID, from, new Text(`Hello ${name}!`));
+Whatsapp.on.message = ({ name, reply }) => {
+    reply(new Text(`Hello ${name}!`));
 };
 
 async function doPost(e) {

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ async function post(e) {
     );
 }
 
-Whatsapp.on.message = async ({ phoneID, from, message, name }) => {
+Whatsapp.on.message = async ({ phoneID, from, message, name, reply }) => {
     console.log(
         `User ${name} (${from}) sent to bot ${phoneID} ${JSON.stringify(
             message
@@ -65,34 +65,26 @@ Whatsapp.on.message = async ({ phoneID, from, message, name }) => {
     let promise;
 
     if (message.type === "text") {
-        promise = Whatsapp.sendMessage(
-            phoneID,
-            from,
+        promise = reply(
             new Text(`*${name}* said:\n\n${message.text.body}`),
-            message.id
+            true
         );
     }
 
     if (message.type === "image") {
-        promise = Whatsapp.sendMessage(
-            phoneID,
-            from,
+        promise = reply(
             new Image(message.image.id, true, `Nice photo, ${name}`)
         );
     }
 
     if (message.type === "document") {
-        promise = Whatsapp.sendMessage(
-            phoneID,
-            from,
+        promise = reply(
             new Document(message.document.id, true, undefined, "Our document")
         );
     }
 
     if (message.type === "contacts") {
-        promise = Whatsapp.sendMessage(
-            phoneID,
-            from,
+        promise = reply(
             new Contacts.Contacts(
                 [
                     new Contacts.Name(name, "First name", "Last name"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "whatsapp-api-js",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "author": "Secreto31126",
     "description": "A TypeScript server agnostic Whatsapp's Official API framework",
     "license": "MIT",

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -88,7 +88,8 @@ export type OnMessageArgs = {
      * A method to easily reply to the user who sent the message
      */
     reply: (
-        message: ClientMessage
+        response: ClientMessage,
+        context: boolean
     ) => Promise<ServerMessageResponse | Response>;
 };
 

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -1,3 +1,4 @@
+import { Response } from "undici";
 import type {
     ClientMessage,
     ClientMessageRequest,
@@ -83,6 +84,12 @@ export type OnMessageArgs = {
      * The raw data from the API
      */
     raw: PostData;
+    /**
+     * A method to easily reply to the user who sent the message
+     */
+    reply: (
+        message: ClientMessage
+    ) => Promise<ServerMessageResponse | Response>;
 };
 
 /**

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -86,6 +86,10 @@ export type OnMessageArgs = {
     raw: PostData;
     /**
      * A method to easily reply to the user who sent the message
+     *
+     * @param response - The message to send as a reply
+     * @param context - Wether to mention the current message
+     * @returns WhatsAppAPI.sendMessage return value
      */
     reply: (
         response: ClientMessage,

--- a/src/index.ts
+++ b/src/index.ts
@@ -778,7 +778,8 @@ export default class WhatsAppAPI {
                 from,
                 message,
                 name,
-                raw: data
+                raw: data,
+                reply: (m) => this.sendMessage(phoneID, from, m)
             };
 
             this.offload(this.on?.message, args);

--- a/src/index.ts
+++ b/src/index.ts
@@ -779,7 +779,13 @@ export default class WhatsAppAPI {
                 message,
                 name,
                 raw: data,
-                reply: (m) => this.sendMessage(phoneID, from, m)
+                reply: (response, context = false) =>
+                    this.sendMessage(
+                        phoneID,
+                        from,
+                        response,
+                        context ? message.id : undefined
+                    )
             };
 
             this.offload(this.on?.message, args);

--- a/test/index.test.cjs
+++ b/test/index.test.cjs
@@ -1694,7 +1694,7 @@ describe("WhatsAppAPI", function () {
 
                     Whatsapp.on.message = async ({ reply }) => {
                         reply(new Text("Hello World"));
-                    }
+                    };
 
                     Whatsapp.post(valid_message_mock);
 

--- a/test/index.test.cjs
+++ b/test/index.test.cjs
@@ -1635,6 +1635,21 @@ describe("WhatsAppAPI", function () {
             });
 
             describe("Messages", function () {
+                const expectedResponse = {
+                    messaging_product: "whatsapp",
+                    contacts: [
+                        {
+                            input: user,
+                            wa_id: user
+                        }
+                    ],
+                    messages: [
+                        {
+                            id
+                        }
+                    ]
+                };
+
                 let spy_on_message;
                 this.beforeEach(function () {
                     spy_on_message = sinon_spy();
@@ -1660,6 +1675,33 @@ describe("WhatsAppAPI", function () {
                         name,
                         raw: valid_message_mock
                     });
+                });
+
+                it("should reply to a message with the method reply", async function () {
+                    const spy_on_sent = sinon_spy();
+                    Whatsapp.on.sent = spy_on_sent;
+
+                    clientFacebook
+                        .intercept({
+                            path: `/${Whatsapp.v}/${phoneID}/messages`,
+                            method: "POST",
+                            headers: {
+                                Authorization: `Bearer ${token}`
+                            }
+                        })
+                        .reply(200, expectedResponse)
+                        .times(1);
+
+                    Whatsapp.on.message = async ({ reply }) => {
+                        reply(new Text("Hello World"));
+                    }
+
+                    Whatsapp.post(valid_message_mock);
+
+                    // Callbacks are executed in the next tick
+                    await new Promise((resolve) => setTimeout(resolve, 0));
+
+                    sinon_assert.calledOnce(spy_on_sent);
                 });
 
                 it("should not block the main thread with the user's callback", async function () {


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

-   [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
-   [x] This message body should clearly illustrate what problems it solves.
-   [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

-   [x] Run the tests with `npm run test` and lint the project with `npm run lint` and `npm run prettier`

Who doesn't hate code repetition? The new `reply` method aims at not only saving 20/30 chars per message, but also allow code splitting without needing to create another WhatsAppAPI instance.
