### PR TITLE
Add Native Flow Response reply type definition

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -533,6 +533,12 @@ export type ServerInteractiveMessage = {
               };
               button_reply: never;
           };
+        | {
+            "type":"nfm_reply";
+            "nfm_reply": {
+                "response_json": any,
+            }
+          } ⁠
 };
 
 export type ServerButtonMessage = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -535,10 +535,23 @@ export type ServerInteractiveMessage = {
           }
         | {
             "type":"nfm_reply";
-            "nfm_reply": {
-                "response_json": any,
+            "nfm_reply": 
+            | {
+                "name": "address_reply",
+                "body": string | undefined,
+                "response_json": any
             }
-          };
+            | {
+                "name": "flow",
+                "body": "Sent",
+                "response_json": any
+            }
+            | {
+                "name": string | undefined,
+                "body": string | undefined,
+                "response_json": any
+            };
+        };
 };
 
 export type ServerButtonMessage = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -532,13 +532,13 @@ export type ServerInteractiveMessage = {
                   description: string;
               };
               button_reply: never;
-          };
+          }
         | {
             "type":"nfm_reply";
             "nfm_reply": {
                 "response_json": any,
             }
-          } ⁠
+          };
 };
 
 export type ServerButtonMessage = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -539,7 +539,7 @@ export type ServerInteractiveMessage = {
               type: "nfm_reply";
               nfm_reply:
                   | {
-                        name: "address_reply";
+                        name: "address_message";
                         body?: string;
                         response_json: unknown;
                     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -534,24 +534,24 @@ export type ServerInteractiveMessage = {
               button_reply: never;
           }
         | {
-            "type":"nfm_reply";
-            "nfm_reply": 
-            | {
-                "name": "address_reply",
-                "body": string | undefined,
-                "response_json": any
-            }
-            | {
-                "name": "flow",
-                "body": "Sent",
-                "response_json": any
-            }
-            | {
-                "name": string | undefined,
-                "body": string | undefined,
-                "response_json": any
-            };
-        };
+              type: "nfm_reply";
+              nfm_reply:
+                  | {
+                        name: "address_reply";
+                        body: string | undefined;
+                        response_json: unknown;
+                    }
+                  | {
+                        name: "flow";
+                        body: "Sent";
+                        response_json: unknown;
+                    }
+                  | {
+                        name: string | undefined;
+                        body: string | undefined;
+                        response_json: unknown;
+                    };
+          };
 };
 
 export type ServerButtonMessage = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -523,6 +523,7 @@ export type ServerInteractiveMessage = {
                   title: string;
               };
               list_reply: never;
+              nfm_reply: never;
           }
         | {
               type: "list_reply";
@@ -532,13 +533,14 @@ export type ServerInteractiveMessage = {
                   description: string;
               };
               button_reply: never;
+              nfm_reply: never;
           }
         | {
               type: "nfm_reply";
               nfm_reply:
                   | {
                         name: "address_reply";
-                        body: string | undefined;
+                        body?: string;
                         response_json: unknown;
                     }
                   | {
@@ -547,10 +549,12 @@ export type ServerInteractiveMessage = {
                         response_json: unknown;
                     }
                   | {
-                        name: string | undefined;
-                        body: string | undefined;
+                        name?: string;
+                        body?: string;
                         response_json: unknown;
                     };
+              button_reply: never;
+              list_reply: never;
           };
 };
 


### PR DESCRIPTION
This PR adds the type definition for an interactive nfp_reply message. This message is received when sharing an address, or completing an flow.