### PR TITLE
Emitters update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "whatsapp-api-js",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "author": "Secreto31126",
     "description": "A TypeScript server agnostic Whatsapp's Official API framework",
     "license": "MIT",

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -47,6 +47,12 @@ export type OnSentArgs = {
      */
     id?: string;
     /**
+     * If true, the message send was delayed until quality can be validated and it will
+     * either be sent or dropped at this point. Undefined if parsed is set to false or
+     * the message_status property is not present in the response.
+     */
+    held_for_quality_assessment?: boolean;
+    /**
      * The parsed response from the server, undefined if parsed is set to false
      */
     response?: ServerMessageResponse;

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -138,6 +138,10 @@ export type OnStatusArgs = {
      */
     id: string;
     /**
+     * The message timestamp
+     */
+    timestamp: string;
+    /**
      * The conversation object
      */
     conversation?: ServerConversation;

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,6 +262,14 @@ export class WhatsAppAPI {
                     ? response.messages[0].id
                     : undefined
                 : undefined,
+            held_for_quality_assessment: response
+                ? "messages" in response
+                    ? "message_status" in response.messages[0]
+                        ? response.messages[0].message_status ===
+                          "held_for_quality_assessment"
+                        : undefined
+                    : undefined
+                : undefined,
             response
         };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -843,6 +843,7 @@ export class WhatsAppAPI {
             const phone = statuses.recipient_id;
             const status = statuses.status;
             const id = statuses.id;
+            const timestamp = statuses.timestamp;
             const conversation = statuses.conversation;
             const pricing = statuses.pricing;
             const error = statuses.errors?.[0];
@@ -853,6 +854,7 @@ export class WhatsAppAPI {
                 phone,
                 status,
                 id,
+                timestamp,
                 conversation,
                 pricing,
                 error,

--- a/src/types.ts
+++ b/src/types.ts
@@ -809,6 +809,7 @@ export type ServerSentMessageResponse = {
     messages: [
         {
             id: string;
+            message_status?: "accepted" | "held_for_quality_assessment";
         }
     ];
 };


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

-   [x] It's really useful if your PR references an issue where it is discussed ahead of time.
-   [x] This message body should clearly illustrate what problems it solves.
-   [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

-   [x] Run the tests with `npm run test` and lint the project with `npm run lint` and `npm run prettier`

Based on #325, I decided to implement the requested changes with a different perspective.

The `message_status` property is still missing from my tests to the API, so I decided to implement it as an optional, and rather than asumming success, use it to indicate the user that the message is `held_for_quality_assessment` if the value says so.

On the other hand, the `timestamp` argument was added to the OnStatus emitter, which was not able to access it otherwise. OnMessage can read the property by using `message.timestamp`. OnSent has no way to know the timestamp, and using the client timestamp might be inconsistent with the API timezone, hence omitted.

Thanks @ekoeryanto for all the help! I tried to be as loyal to your original PR as I could, while also being consistent with the API. I will look into the package manager action _eventually_. Can't promise anything yet :)