### PR TITLE
Allow emitters to return custom data

### DIFF
--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -64,7 +64,7 @@ export type OnSentArgs = {
  * @public
  * @param args - The arguments object
  */
-export type OnMessage = (args: OnMessageArgs) => unknown;
+export type OnMessage<Returns> = (args: OnMessageArgs) => Returns;
 
 /**
  * @public
@@ -115,7 +115,7 @@ export type OnMessageArgs = {
  * @public
  * @param args - The arguments object
  */
-export type OnStatus = (args: OnStatusArgs) => unknown;
+export type OnStatus<Returns> = (args: OnStatusArgs) => Returns;
 
 /**
  * @public

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -104,6 +104,11 @@ export type OnMessageArgs = {
         biz_opaque_callback_data?: string
     ) => Promise<ServerMessageResponse | Response>;
     /**
+     * Utility function for offloading code from the main thread,
+     * useful for long running tasks such as AI generation
+     */
+    offload: typeof WhatsAppAPI.offload;
+    /**
      * The WhatsAppAPI instance that emitted the event
      */
     Whatsapp: InstanceType<typeof WhatsAppAPI>;
@@ -157,6 +162,11 @@ export type OnStatusArgs = {
      * Arbitrary string included in sent messages
      */
     biz_opaque_callback_data?: string;
+    /**
+     * Utility function for offloading code from the main thread,
+     * useful for long running tasks such as AI generation
+     */
+    offload: typeof WhatsAppAPI.offload;
     /**
      * The raw data from the API
      */

--- a/src/middleware/adonis.ts
+++ b/src/middleware/adonis.ts
@@ -33,11 +33,13 @@ export class WhatsAppAPI extends WhatsAppAPIMiddleware {
      */
     async handle_post(req: Request) {
         try {
-            return await this.post(
+            await this.post(
                 req.body() as PostData,
                 req.raw() ?? "",
                 req.header("x-hub-signature-256") ?? ""
             );
+
+            return 200;
         } catch (e) {
             // In case who knows what fails ¯\_(ツ)_/¯
             return isInteger(e) ? e : 500;

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -43,11 +43,13 @@ export class WhatsAppAPI extends WhatsAppAPIMiddleware {
      */
     async handle_post(req: Request) {
         try {
-            return this.post(
+            await this.post(
                 JSON.parse(req.body ?? "{}"),
                 req.body,
                 req.header("x-hub-signature-256")
             );
+
+            return 200;
         } catch (e) {
             // In case the JSON.parse fails ¯\_(ツ)_/¯
             return isInteger(e) ? e : 500;

--- a/src/middleware/globals.ts
+++ b/src/middleware/globals.ts
@@ -4,7 +4,7 @@ import { WhatsAppAPI } from "../index.js";
  * The abstract class for the middlewares, it extends the WhatsAppAPI class
  * and defines the handle_post and handle_get methods for its childs.
  */
-export abstract class WhatsAppAPIMiddleware extends WhatsAppAPI {
+export abstract class WhatsAppAPIMiddleware extends WhatsAppAPI<void> {
     /**
      * This method should be called when the server receives a POST request.
      * Each child implements it differently depending on the framework.

--- a/src/middleware/node-http.ts
+++ b/src/middleware/node-http.ts
@@ -64,7 +64,9 @@ export class WhatsAppAPI extends WhatsAppAPIMiddleware {
 
             if (typeof signature !== "string") throw 400;
 
-            return this.post(JSON.parse(body || "{}"), body, signature);
+            await this.post(JSON.parse(body || "{}"), body, signature);
+
+            return 200;
         } catch (e) {
             // In case the JSON.parse fails ¯\_(ツ)_/¯
             return isInteger(e) ? e : 500;

--- a/src/middleware/web-standard.ts
+++ b/src/middleware/web-standard.ts
@@ -18,11 +18,13 @@ export class WhatsAppAPI extends WhatsAppAPIMiddleware {
         try {
             const body = await req.text();
 
-            return this.post(
+            await this.post(
                 JSON.parse(body || "{}"),
                 body,
                 req.headers.get("x-hub-signature-256") ?? ""
             );
+
+            return 200;
         } catch (e) {
             // In case the JSON.parse fails ¯\_(ツ)_/¯
             return isInteger(e) ? e : 500;

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,11 +71,6 @@ export type TheBasicConstructorArguments = {
      */
     parsed?: boolean;
     /**
-     * If false, the user functions won't be offloaded from the main event loop.
-     * Intended for Serverless Environments where the process might be killed after the main function finished.
-     */
-    offload_functions?: boolean;
-    /**
      * If set to false, none of the API checks will be performed, and it will be used in a less secure way.
      *
      * Defaults to true.


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

-   [x] It's really useful if your PR references an issue where it is discussed ahead of time.
-   [x] This message body should clearly illustrate what problems it solves.
-   [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

-   [x] Run the tests with `npm run test` and lint the project with `npm run lint` and `npm run prettier`

https://github.com/Secreto31126/whatsapp-api-js/issues/335#issuecomment-2103905066

Now it's possible to return custom data from the OnMessage and OnStatus events, which will be the post() return value.