### PR TITLE
Fix verify signature double negation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -976,7 +976,7 @@ export class WhatsAppAPI<EmittersReturnType = void> {
             .map((b) => b.toString(16).padStart(2, "0"))
             .join("");
 
-        return signature !== check;
+        return signature === check;
     }
 
     /**

--- a/test/index.test.cjs
+++ b/test/index.test.cjs
@@ -1629,7 +1629,11 @@ describe("WhatsAppAPI", function () {
 
                     it("should throw 401 if the signature doesn't match the hash", async function () {
                         await rejects(
-                            Whatsapp.post(valid_message_mock, body, "wrong"),
+                            Whatsapp.post(
+                                valid_message_mock,
+                                body,
+                                "sha256=wrong"
+                            ),
                             threw(401)
                         );
                     });


### PR DESCRIPTION
I want to fix the verifyRequestSignature method inside `index.ts` file. From the jsdoc docs,  the returnred boolean value should indicate that the signature is valid. Hope it helps! :) 

### PR Checklist

-   [x] It's really useful if your PR references an issue where it is discussed ahead of time.
-   [x] This message body should clearly illustrate what problems it solves.
-   [-] Ideally, include a test that fails without this PR but passes with it.

### Tests

-   [-] Run the tests with `npm run test` and lint the project with `npm run lint` and `npm run prettier`
