### PR TITLE
Library error classes

### DIFF
--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -214,7 +214,7 @@ async function doPost(e) {
     try {
         status_code = await Whatsapp.post(data);
     } catch (e) {
-        status_code = e;
+        status_code = e?.httpStatus ?? 500;
     }
 
     // GAS doesn't support sending custom status codes

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
         "./types": {
             "types": "./lib/types.d.ts",
             "import": "./lib/types.js"
+        },
+        "./errors": {
+            "types": "./lib/errors.d.ts",
+            "import": "./lib/errors.js"
         }
     },
     "//": [
@@ -76,6 +80,9 @@
             ],
             "types": [
                 "lib/types.d.ts"
+            ],
+            "errors": [
+                "lib/errors.d.ts"
             ]
         }
     },

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -226,6 +226,116 @@ export class WhatsAppAPIFailedToVerifyError extends WhatsAppAPIError {
 }
 
 /**
+ * Thrown when the Webhook Verify Token isn't provided in the constructor
+ *
+ * @description
+ * The Webhook Verify Token is a custom secret key that is used to verify against the API
+ * the server is indeed the one that is supposed to receive the incoming requests.
+ *
+ * Your server will receive a GET request with the `hub.verify_token` and `hub.challenge` parameters.
+ * The verify token should be equal to the one you provided in the constructor.
+ * Once validated, you should reply with the `hub.challenge` parameter.
+ *
+ * The verify token is manually generated while setting up the callback URL in the
+ * Meta's app dashboard -\> WhatsApp -\> Configuration.
+ *
+ * @example
+ * ```ts
+ * new WhatsAppAPI({
+ *     webhookVerifyToken: "your-verify-token",
+ *     // other options
+ * });
+ * ```
+ *
+ * @see https://whatsappapijs.web.app/types/types.TheBasicConstructorArguments.html
+ * @see https://developers.facebook.com/docs/graph-api/webhooks/getting-started/#verification-requests
+ */
+export class WhatsAppAPIMissingVerifyTokenError extends WhatsAppAPIError {
+    /**
+     * @internal
+     */
+    constructor() {
+        super("Missing verify token", 500);
+    }
+
+    /**
+     * @override
+     */
+    get docs() {
+        return this.url("WhatsAppAPIMissingVerifyTokenError");
+    }
+}
+
+/**
+ * Thrown when the search parameters are missing in the request
+ *
+ * @description
+ * In order to validate your server against the API, you need to provide the request params.
+ *
+ * If you are NOT using a middleware, make sure you are passing the parameters correctly.
+ * Otherwise, feel free to open an issue on {@link https://github.com/Secreto31126/whatsapp-api-js/issues | GitHub}.
+ *
+ * @see https://whatsappapijs.web.app/types/types.GetParams.html
+ * @see https://developers.facebook.com/docs/graph-api/webhooks/getting-started/#verification-requests
+ */
+export class WhatsAppAPIMissingSearchParamsError extends WhatsAppAPIError {
+    /**
+     * @internal
+     */
+    constructor() {
+        super("Missing search params", 400);
+    }
+
+    /**
+     * @override
+     */
+    get docs() {
+        return this.url("WhatsAppAPIMissingSearchParamsError");
+    }
+}
+
+/**
+ * Thrown when the verification token doesn't match from the request
+ *
+ * @description
+ * The verify_token in the request doesn't match the one provided on initialization.
+ * Either they are hacking you, or your Webhook Verify Token is invalid.
+ *
+ * Make sure you provided the correct verify token on initialization.
+ * It is manually generated while setting up the callback URL in the
+ * Meta's app dashboard -\> WhatsApp -\> Configuration.
+ *
+ * @example
+ * ```ts
+ * new WhatsAppAPI({
+ *     webhookVerifyToken: "your-verify-token",
+ *     // other options
+ * });
+ * ```
+ *
+ * @description
+ * It might also be possible you didn't provide the correct request params
+ * for the verification token (hub.verify_token). If you are using a middleware and
+ * this seems to be the case, consider opening an issue on
+ * {@link https://github.com/Secreto31126/whatsapp-api-js/issues | GitHub}.
+ */
+export class WhatsAppAPIFailedToVerifyTokenError extends WhatsAppAPIError {
+    /**
+     * @internal
+     */
+    constructor() {
+        super("Invalid token verification", 403);
+    }
+
+    /**
+     * @override
+     */
+    get docs() {
+        return this.url("WhatsAppAPIFailedToVerifyTokenError");
+    }
+}
+
+/**
  * Thrown in unusual cases, such as on empty or unknown payloads from the API side.
  *
  * It 100% should never happen, and if it does, feel free to open an issue on

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,9 +1,20 @@
 /**
  * @module errors
  *
+ * @description
  * This module contains the custom errors that are thrown by the
- * {@link index.ts#WhatsAppAPI.get} and {@link index.ts#WhatsAppAPI.post} methods.
+ * {@link WhatsAppAPI.get} and {@link WhatsAppAPI.post} methods.
+ *
+ * I did my best to explain why each error happens, include examples,
+ * a few tips, and links to sources for further reading.
+ *
+ * This file is 300 lines of docs and the remaining is the actual code.
+ * So yeah, enjoy reading :]
  */
+
+// This import makes the docs' links work
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { WhatsAppAPI } from "./index";
 
 /**
  * The library's base exception class.
@@ -318,6 +329,11 @@ export class WhatsAppAPIMissingSearchParamsError extends WhatsAppAPIError {
  * for the verification token (hub.verify_token). If you are using a middleware and
  * this seems to be the case, consider opening an issue on
  * {@link https://github.com/Secreto31126/whatsapp-api-js/issues | GitHub}.
+ *
+ * @see https://whatsappapijs.web.app/classes/WhatsAppAPI.WhatsAppAPI.html#get
+ * @see https://whatsappapijs.web.app/types/types.TheBasicConstructorArguments.html
+ * @see https://whatsappapijs.web.app/types/types.GetParams.html
+ * @see https://developers.facebook.com/docs/graph-api/webhooks/getting-started/#verification-requests
  */
 export class WhatsAppAPIFailedToVerifyTokenError extends WhatsAppAPIError {
     /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,246 @@
+/**
+ * @module errors
+ *
+ * This module contains the custom errors that are thrown by the
+ * {@link index.ts#WhatsAppAPI.get} and {@link index.ts#WhatsAppAPI.post} methods.
+ */
+
+/**
+ * The library's base exception class.
+ */
+export abstract class WhatsAppAPIError extends Error {
+    /**
+     * The HTTP status code of the error
+     */
+    readonly httpStatus: number;
+
+    /**
+     * @internal
+     */
+    constructor(message: string, httpStatus: number) {
+        super(message);
+        this.name = "WhatsAppAPIError";
+        this.httpStatus = httpStatus;
+    }
+
+    protected url(name: string) {
+        return `https://whatsappapijs.web.app/classes/errors.${name}.html`;
+    }
+
+    /**
+     * @returns The URL to the error's documentation
+     */
+    abstract get docs(): string;
+}
+
+/**
+ * Thrown when the request body is missing
+ *
+ * @description
+ * In order to validate the request, the raw body (original string) of the request is required to do the signature verification.
+ *
+ * If you are using a middleware, make sure you aren't consuming the request body before the API can access it.
+ * Otherwise, feel free to open an issue on {@link https://github.com/Secreto31126/whatsapp-api-js/issues | GitHub}.
+ *
+ * @example
+ * ```ts
+ * await whatsapp.post(JSON.parse(req.body), req.body, req.headers.get("x-hub-signature-256"));
+ * ```
+ *
+ * @see https://whatsappapijs.web.app/classes/WhatsAppAPI.WhatsAppAPI.html#post
+ */
+export class WhatsAppAPIMissingRawBodyError extends WhatsAppAPIError {
+    /**
+     * @internal
+     */
+    constructor() {
+        super("Missing raw body", 400);
+    }
+
+    /**
+     * @override
+     */
+    get docs() {
+        return this.url("WhatsAppAPIMissingRawBodyError");
+    }
+}
+
+/**
+ * Thrown when the request's signature is missing
+ *
+ * @description
+ * In order to validate the request, the `x-hub-signature-256` header is required to do the signature verification.
+ *
+ * If you are NOT using a middleware, make sure you are passing the headers correctly (check case sensitivity).
+ * Otherwise, feel free to open an issue on {@link https://github.com/Secreto31126/whatsapp-api-js/issues | GitHub}.
+ *
+ * @example
+ * ```ts
+ * await whatsapp.post(JSON.parse(req.body), req.body, req.headers.get("x-hub-signature-256"));
+ * ```
+ *
+ * @see https://whatsappapijs.web.app/classes/WhatsAppAPI.WhatsAppAPI.html#post
+ */
+export class WhatsAppAPIMissingSignatureError extends WhatsAppAPIError {
+    /**
+     * @internal
+     */
+    constructor() {
+        super("Missing signature", 401);
+    }
+
+    /**
+     * @override
+     */
+    get docs() {
+        return this.url("WhatsAppAPIMissingSignatureError");
+    }
+}
+
+/**
+ * Thrown when the App Secret isn't provided in the constructor
+ *
+ * @description
+ * The App Secret is a private key that is used to verify the authenticity of the incoming requests.
+ * It can be found in your Meta's app dashboard, inside App Settings -\> Basic.
+ *
+ * @example
+ * ```ts
+ * new WhatsAppAPI({
+ *     appSecret: "your-app-secret",
+ *     // other options
+ * });
+ * ```
+ *
+ * @see https://whatsappapijs.web.app/types/types.TheBasicConstructorArguments.html
+ */
+export class WhatsAppAPIMissingAppSecretError extends WhatsAppAPIError {
+    /**
+     * @internal
+     */
+    constructor() {
+        super("Missing app secret", 500);
+    }
+
+    /**
+     * @override
+     */
+    get docs() {
+        return this.url("WhatsAppAPIMissingAppSecretError");
+    }
+}
+
+/**
+ * Thrown when the `crypto.subtle` API isn't available in the current environment
+ *
+ * @description
+ * The `crypto.subtle` API is required to verify the signature of the incoming requests.
+ * However, it isn't available in all environments. If your environment doesn't support it,
+ * you can provide a ponyfill for it in the `crypto` option of the `WhatsAppAPI` constructor.
+ *
+ * @example
+ * ```ts
+ * new WhatsAppAPI({
+ *     appSecret: "your-app-secret",
+ *     ponyfill: {
+ *         subtle: my_custom_crypto.subtle
+ *     },
+ *     // other options
+ * });
+ * ```
+ *
+ * @see https://whatsappapijs.web.app/types/types.TheBasicConstructorArguments.html
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto (specifically, `importKey` and `sign` methods)
+ */
+export class WhatsAppAPIMissingCryptoSubtleError extends WhatsAppAPIError {
+    /**
+     * @internal
+     */
+    constructor() {
+        super("Missing crypto subtle", 501);
+    }
+
+    /**
+     * @override
+     */
+    get docs() {
+        return this.url("WhatsAppAPIMissingCryptoSubtleError");
+    }
+}
+
+/**
+ * Thrown when the signature provided in the request's headers isn't valid
+ *
+ * @description
+ * The signature provided in the request's headers isn't valid.
+ * Either they are hacking you, or your App Secret is invalid.
+ *
+ * Make sure you provided the correct app secret on initialization.
+ * It can be found in your Meta's app dashboard, inside App Settings -\> Basic.
+ *
+ * @example
+ * ```ts
+ * new WhatsAppAPI({
+ *     appSecret: "your-app-secret",
+ *     // other options
+ * });
+ * ```
+ *
+ * @description
+ * It might also be possible you didn't provide the correct request header
+ * for the signature (x-hub-signature-256). If you are using a middleware and
+ * this seems to be the case, consider opening an issue on
+ * {@link https://github.com/Secreto31126/whatsapp-api-js/issues | GitHub}.
+ *
+ * ⚠ If you are just testing the API, you can disable the signature verification
+ * by setting the `secure` option to `false` on the `WhatsAppAPI` constructor.
+ * Obviously, this is not recommended for production.
+ *
+ * @example
+ * ```ts
+ * new WhatsAppAPI({
+ *     // appSecret: "Not required",
+ *     secure: false,
+ *     // other options
+ * });
+ * ```
+ *
+ * @see https://whatsappapijs.web.app/classes/WhatsAppAPI.WhatsAppAPI.html#post
+ * @see https://whatsappapijs.web.app/types/types.TheBasicConstructorArguments.html
+ * @see https://developer.mozilla.org/docs/Web/HTTP/Headers
+ */
+export class WhatsAppAPIFailedToVerifyError extends WhatsAppAPIError {
+    /**
+     * @internal
+     */
+    constructor() {
+        super("Signature doesn't match", 401);
+    }
+
+    /**
+     * @override
+     */
+    get docs() {
+        return this.url("WhatsAppAPIFailedToVerifyError");
+    }
+}
+
+/**
+ * Thrown in unusual cases, such as on empty or unknown payloads from the API side.
+ *
+ * It 100% should never happen, and if it does, feel free to open an issue on
+ * {@link https://github.com/Secreto31126/whatsapp-api-js/issues | GitHub} so we can
+ * investigate these impossibles scenarios.
+ */
+export class WhatsAppAPIUnexpectedError extends WhatsAppAPIError {
+    /**
+     * @internal
+     */
+    constructor(message: string, httpStatus: number) {
+        super(message + " ¯\\_(ツ)_/¯", httpStatus);
+    }
+
+    get docs() {
+        return this.url("WhatsAppAPIUnexpectedError");
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -873,7 +873,7 @@ export class WhatsAppAPI<EmittersReturnType = void> {
                 Whatsapp: this
             };
 
-            return await this.on?.message?.(args);
+            return this.on?.message?.(args);
         } else if ("statuses" in value) {
             const statuses = value.statuses[0];
 
@@ -901,7 +901,7 @@ export class WhatsAppAPI<EmittersReturnType = void> {
                 Whatsapp: this
             };
 
-            return await this.on?.status?.(args);
+            return this.on?.status?.(args);
         }
 
         // If unknown payload, just ignore it

--- a/src/index.ts
+++ b/src/index.ts
@@ -768,6 +768,7 @@ export class WhatsAppAPI<EmittersReturnType = void> {
      * // author arivanbastos on issue #114
      * // Simple http example implementation with Whatsapp.post() on Node@^19
      * import { WhatsAppAPI } from "whatsapp-api-js";
+     * import { WhatsAppAPIError } from "whatsapp-api-js/errors";
      * import { NodeNext } from "whatsapp-api-js/setup/node";
      *
      * import { createServer } from "http";
@@ -788,7 +789,7 @@ export class WhatsAppAPI<EmittersReturnType = void> {
      *                 const response = await Whatsapp.post(JSON.parse(body), body, req.headers["x-hub-signature-256"]);
      *                 res.writeHead(response);
      *             } catch (err) {
-     *                 res.writeHead(err);
+     *                 res.writeHead(err instanceof WhatsAppAPIError ? err.httpStatus : 500);
      *             }
      *
      *             res.end();

--- a/src/index.ts
+++ b/src/index.ts
@@ -917,6 +917,7 @@ export class WhatsAppAPI<EmittersReturnType = void> {
      * ```ts
      * // Simple http example implementation with Whatsapp.get() on Node@^19
      * import { WhatsAppAPI } from "whatsapp-api-js";
+     * import { WhatsAppAPIError } from "whatsapp-api-js/errors";
      * import { NodeNext } from "whatsapp-api-js/setup/node";
      *
      * import { createServer } from "http";
@@ -929,10 +930,14 @@ export class WhatsAppAPI<EmittersReturnType = void> {
      *     if (req.method == "GET") {
      *         const params = new URLSearchParams(req.url.split("?")[1]);
      *
-     *         const response = Whatsapp.get(Object.fromEntries(params));
+     *         try {
+     *             const response = Whatsapp.get(Object.fromEntries(params));
+     *             res.writeHead(200, {"Content-Type": "text/html"});
+     *             res.write(response);
+     *         } catch (err) {
+     *             res.writeHead(err instanceof WhatsAppAPIError ? err.httpStatus : 500);
+     *         }
      *
-     *         res.writeHead(200, {"Content-Type": "text/html"});
-     *         res.write(response)
      *         res.end();
      *     } else res.writeHead(501).end();
      * };

--- a/src/middleware/adonis.ts
+++ b/src/middleware/adonis.ts
@@ -1,5 +1,5 @@
 import { WhatsAppAPIMiddleware } from "./globals.js";
-import { isInteger } from "../utils.js";
+import { WhatsAppAPIError } from "../errors.js";
 
 import type { Request } from "@adonisjs/http-server";
 import type { GetParams, PostData } from "../types";
@@ -42,7 +42,7 @@ export class WhatsAppAPI extends WhatsAppAPIMiddleware {
             return 200;
         } catch (e) {
             // In case who knows what fails ¯\_(ツ)_/¯
-            return isInteger(e) ? e : 500;
+            return e instanceof WhatsAppAPIError ? e.httpStatus : 500;
         }
     }
 
@@ -79,7 +79,7 @@ export class WhatsAppAPI extends WhatsAppAPIMiddleware {
             return this.get(req.qs() as GetParams);
         } catch (e) {
             // In case who knows what fails ¯\_(ツ)_/¯
-            throw isInteger(e) ? e : 500;
+            throw e instanceof WhatsAppAPIError ? e.httpStatus : 500;
         }
     }
 }

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -1,5 +1,5 @@
 import { WhatsAppAPIMiddleware } from "./globals.js";
-import { isInteger } from "../utils.js";
+import { WhatsAppAPIError } from "../errors.js";
 
 import type { Request } from "express";
 import type { GetParams } from "../types";
@@ -52,7 +52,7 @@ export class WhatsAppAPI extends WhatsAppAPIMiddleware {
             return 200;
         } catch (e) {
             // In case the JSON.parse fails ¯\_(ツ)_/¯
-            return isInteger(e) ? e : 500;
+            return e instanceof WhatsAppAPIError ? e.httpStatus : 500;
         }
     }
 
@@ -90,7 +90,7 @@ export class WhatsAppAPI extends WhatsAppAPIMiddleware {
             return this.get(req.query as GetParams);
         } catch (e) {
             // In case who knows what fails ¯\_(ツ)_/¯
-            throw isInteger(e) ? e : 500;
+            throw e instanceof WhatsAppAPIError ? e.httpStatus : 500;
         }
     }
 }

--- a/src/middleware/node-http.ts
+++ b/src/middleware/node-http.ts
@@ -1,5 +1,5 @@
 import { WhatsAppAPIMiddleware } from "./globals.js";
-import { isInteger } from "../utils.js";
+import { WhatsAppAPIError } from "../errors.js";
 
 import type { IncomingMessage } from "node:http";
 import type { Readable } from "node:stream";
@@ -69,7 +69,7 @@ export class WhatsAppAPI extends WhatsAppAPIMiddleware {
             return 200;
         } catch (e) {
             // In case the JSON.parse fails ¯\_(ツ)_/¯
-            return isInteger(e) ? e : 500;
+            return e instanceof WhatsAppAPIError ? e.httpStatus : 500;
         }
     }
 
@@ -110,7 +110,7 @@ export class WhatsAppAPI extends WhatsAppAPIMiddleware {
             );
         } catch (e) {
             // In case who knows what fails ¯\_(ツ)_/¯
-            throw isInteger(e) ? e : 500;
+            throw e instanceof WhatsAppAPIError ? e.httpStatus : 500;
         }
     }
 }

--- a/src/middleware/vercel.ts
+++ b/src/middleware/vercel.ts
@@ -1,5 +1,5 @@
 import { WhatsAppAPI as NodeHTTPMiddleware } from "./node-http.js";
-import { isInteger } from "../utils.js";
+import { WhatsAppAPIError } from "../errors.js";
 
 import type { VercelRequest } from "@vercel/node";
 import type { GetParams } from "../types.js";
@@ -83,7 +83,7 @@ export class WhatsAppAPI extends NodeHTTPMiddleware {
             return this.get(req.query as GetParams);
         } catch (e) {
             // In case who knows what fails ¯\_(ツ)_/¯
-            throw isInteger(e) ? e : 500;
+            throw e instanceof WhatsAppAPIError ? e.httpStatus : 500;
         }
     }
 }

--- a/src/middleware/web-standard.ts
+++ b/src/middleware/web-standard.ts
@@ -1,5 +1,5 @@
 import { WhatsAppAPIMiddleware } from "./globals.js";
-import { isInteger } from "../utils.js";
+import { WhatsAppAPIError } from "../errors.js";
 
 import type { GetParams } from "../types";
 
@@ -27,7 +27,7 @@ export class WhatsAppAPI extends WhatsAppAPIMiddleware {
             return 200;
         } catch (e) {
             // In case the JSON.parse fails ¯\_(ツ)_/¯
-            return isInteger(e) ? e : 500;
+            return e instanceof WhatsAppAPIError ? e.httpStatus : 500;
         }
     }
 
@@ -46,7 +46,7 @@ export class WhatsAppAPI extends WhatsAppAPIMiddleware {
             );
         } catch (e) {
             // In case who knows what fails ¯\_(ツ)_/¯
-            throw isInteger(e) ? e : 500;
+            throw e instanceof WhatsAppAPIError ? e.httpStatus : 500;
         }
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,11 @@ export type ExtraTypesThatMakeTypescriptWork = SecureLightSwitch;
 export type WhatsAppAPIConstructorArguments = TheBasicConstructorArguments &
     ExtraTypesThatMakeTypescriptWork;
 
+/**
+ * The base class of all the library messages
+ *
+ * Polymorphism is cool :]
+ */
 export abstract class ClientMessage {
     /**
      * The message type

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,10 +2,6 @@ export type AtLeastOne<T> = [T, ...T[]];
 
 export type MaybePromise<T> = T | Promise<T> | PromiseLike<T>;
 
-export function isInteger(n: unknown): n is number {
-    return Number.isInteger(n);
-}
-
 export function escapeUnicode(str: string) {
     // https://stackoverflow.com/a/40558081
     return str.replace(/[^\0-~]/g, (ch) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,6 +10,7 @@ import { describe, it, beforeEach, afterEach } from "node:test";
 import { WhatsAppAPI } from "../lib/middleware/node-http.js";
 import { DEFAULT_API_VERSION } from "../lib/types.js";
 import { Text } from "../lib/messages/text.js";
+import * as LibErrors from "../lib/errors.js";
 
 // Mock the https requests
 import { agent, clientFacebook, clientExample } from "./server.mocks.js";
@@ -1618,47 +1619,47 @@ describe("WhatsAppAPI", () => {
 
             describe("Validation", () => {
                 describe("Secure truthy (default)", () => {
-                    it("should throw 400 if rawBody is missing", async () => {
+                    it("should throw WhatsAppAPIMissingRawBodyError if rawBody is missing", async () => {
                         await rejects(
                             Whatsapp.post(valid_message_mock),
-                            threw(400)
+                            LibErrors.WhatsAppAPIMissingRawBodyError
                         );
 
                         await rejects(
                             Whatsapp.post(valid_message_mock, undefined),
-                            threw(400)
+                            LibErrors.WhatsAppAPIMissingRawBodyError
                         );
                     });
 
-                    it("should throw 401 if signature is missing", async () => {
+                    it("should throw WhatsAppAPIMissingSignatureError if signature is missing", async () => {
                         await rejects(
                             Whatsapp.post(valid_message_mock, body),
-                            threw(401)
+                            LibErrors.WhatsAppAPIMissingSignatureError
                         );
 
                         await rejects(
                             Whatsapp.post(valid_message_mock, body, undefined),
-                            threw(401)
+                            LibErrors.WhatsAppAPIMissingSignatureError
                         );
                     });
 
-                    it("should throw 500 if appSecret is not specified", async () => {
+                    it("should throw WhatsAppAPIMissingAppSecretError if appSecret is not specified", async () => {
                         delete Whatsapp.appSecret;
 
                         await rejects(
                             Whatsapp.post(valid_message_mock, body, signature),
-                            threw(500)
+                            LibErrors.WhatsAppAPIMissingAppSecretError
                         );
                     });
 
-                    it("should throw 401 if the signature doesn't match the hash", async () => {
+                    it("should throw WhatsAppAPIInvalidSignatureError if the signature doesn't match the hash", async () => {
                         await rejects(
                             Whatsapp.post(
                                 valid_message_mock,
                                 body,
                                 "sha256=wrong"
                             ),
-                            threw(401)
+                            LibErrors.WhatsAppAPIInvalidSignatureError
                         );
                     });
                 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1681,7 +1681,10 @@ describe("WhatsAppAPI", () => {
                 it("should throw WhatsAppAPIUnexpectedError if the request isn't a valid WhatsApp Cloud API request (data.object)", async () => {
                     Whatsapp.secure = false;
 
-                    await rejects(Whatsapp.post({}), LibErrors.WhatsAppAPIUnexpectedError);
+                    await rejects(
+                        Whatsapp.post({}),
+                        LibErrors.WhatsAppAPIUnexpectedError
+                    );
                 });
             });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1484,10 +1484,6 @@ describe("WhatsAppAPI", () => {
     });
 
     describe("Webhooks", () => {
-        function threw(i) {
-            return (e) => e === i;
-        }
-
         describe("Get", () => {
             const mode = "subscribe";
             const challenge = "challenge";
@@ -1518,35 +1514,35 @@ describe("WhatsAppAPI", () => {
                 equal(response, challenge);
             });
 
-            it("should throw 500 if webhookVerifyToken is not specified", () => {
+            it("should throw WhatsAppAPIMissingVerifyTokenError if webhookVerifyToken is not specified", () => {
                 delete Whatsapp.webhookVerifyToken;
 
                 throws(() => {
                     Whatsapp.get(params);
-                }, threw(500));
+                }, LibErrors.WhatsAppAPIMissingVerifyTokenError);
             });
 
-            it("should throw 400 if the request is missing data", () => {
+            it("should throw WhatsAppAPIMissingSearchParamsError if the request is missing data", () => {
                 throws(() => {
                     Whatsapp.get({});
-                }, threw(400));
+                }, LibErrors.WhatsAppAPIMissingSearchParamsError);
 
                 throws(() => {
                     Whatsapp.get({ "hub.mode": mode });
-                }, threw(400));
+                }, LibErrors.WhatsAppAPIMissingSearchParamsError);
 
                 throws(() => {
                     Whatsapp.get({ "hub.verify_token": token });
-                }, threw(400));
+                }, LibErrors.WhatsAppAPIMissingSearchParamsError);
             });
 
-            it("should throw 403 if the verification tokens don't match", () => {
+            it("should throw WhatsAppAPIFailedToVerifyTokenError if the verification tokens don't match", () => {
                 throws(() => {
                     Whatsapp.get(
                         { ...params, "hub.verify_token": "wrong" },
                         token
                     );
-                }, threw(403));
+                }, LibErrors.WhatsAppAPIFailedToVerifyTokenError);
             });
         });
 
@@ -1682,10 +1678,10 @@ describe("WhatsAppAPI", () => {
                     });
                 });
 
-                it("should throw 400 if the request isn't a valid WhatsApp Cloud API request (data.object)", async () => {
+                it("should throw WhatsAppAPIUnexpectedError if the request isn't a valid WhatsApp Cloud API request (data.object)", async () => {
                     Whatsapp.secure = false;
 
-                    await rejects(Whatsapp.post({}), threw(400));
+                    await rejects(Whatsapp.post({}), LibErrors.WhatsAppAPIUnexpectedError);
                 });
             });
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -4,6 +4,7 @@
         "src/index.ts",
         "src/types.ts",
         "src/utils.ts",
+        "src/errors.ts",
         "src/emitters.ts",
         "src/messages/index.ts",
         "src/setup/index.ts",


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `npm run test` and lint the project with `npm run lint` and `npm run prettier`

These new classes allow differentiating between user's bugs and library ones, so the external throws are no longer retained by the webhook handlers and helps the developers to better detect and fix their ~bad~ code issues :)

This could also work as an alternative to setting the emitters' return type, as it's now possible to throw whatever you want. Anyway, I think I will preserve the current system as it provides type safety return values rather than unknown from try catch.