### PR TITLE
Drop Node v18 support

### DIFF
--- a/.github/workflows/npm-deploy.yml
+++ b/.github/workflows/npm-deploy.yml
@@ -35,7 +35,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [18.x, 20.x, 22.x]
+                node-version: [20.x, 22.x, 24.x]
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [18.x, 20.x, 22.x]
+                node-version: [20.x, 22.x, 24.x]
 
         steps:
             - uses: actions/checkout@v4

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -43,7 +43,7 @@ app.post("/message", async (req, res) => {
 });
 ```
 
-- Node 18:
+- Node 18 (deprecated):
 
 ```js
 import { WhatsAppAPI } from "whatsapp-api-js";

--- a/src/setup/node.ts
+++ b/src/setup/node.ts
@@ -23,6 +23,7 @@ export function NodeNext(
  *
  * @remarks Assumes that the fetch function is available globally
  *
+ * @deprecated Node 18 reached EoL and is no longer supported by the library
  * @param settings - The WhatsAppAPI arguments
  * @returns A WhatsAppAPI arguments object for Node\@^18
  */


### PR DESCRIPTION
I kinda hated v18 tho, undici was in a weird state and crypto.subtle wasn't globally available yet.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `npm run test` and lint the project with `npm run lint` and `npm run prettier`
