### PR TITLE
New pricing model and removed `parsed` option

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,5 +1,40 @@
 # Breaking changes
 
+## 6.0.0
+
+### WhatsAppAPI methods no longer return the raw fetch response
+
+The `parsed` option was removed from the WhatsAppAPI constructor, and
+now all methods return the API response directly instead of
+`Promise<T | Response>`.
+
+It didn't give the insights it was expected to provide, and it was
+cumbersome to work around.
+
+### Updated types to follow API pricing changes
+
+With the release of the new per-message pricing model, some minor
+types where changed on the webhooks payloads, more specific in the
+pricing and conversation objects.
+
+To the average user, this change should most certainly have no impact.
+
+For more information, check the Cloud API "Updates to Pricing"
+changelog:
+https://developers.facebook.com/docs/whatsapp/pricing/updates-to-pricing
+
+### Drop testing for Node.js 18
+
+Node.js 18 reached EoL, so there's no point in testing with it
+anymore. The setup method Node18 was marked as deprecated. It's
+strongly recommended to stop using any setup method, as they have all
+become mere noops.
+
+### Bumped API version
+
+The default API version was bumped to `v24.0`, the new one with the
+the realease of the PMP model.
+
 ## 5.0.0
 
 ### post() and get() errors

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# whatsapp-api-js v5
+# whatsapp-api-js v6
 
 [![npm](https://img.shields.io/npm/v/whatsapp-api-js?color=4ccc1c)](https://www.npmjs.com/package/whatsapp-api-js)
 [![Contributors](https://img.shields.io/github/all-contributors/Secreto31126/whatsapp-api-js)](#contributors)
@@ -7,7 +7,7 @@ A TypeScript server agnostic Whatsapp's Official API framework.
 
 ## List of contents
 
-- [whatsapp-api-js v5](#whatsapp-api-js-v5)
+- [whatsapp-api-js v6](#whatsapp-api-js-v6)
     - [List of contents](#list-of-contents)
     - [Set up](#set-up)
     - [Examples and Tutorials](#examples-and-tutorials)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 5       | :white_check_mark: |
-| < 5     | :x:                |
+| 6       | :white_check_mark: |
+| < 6     | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "whatsapp-api-js",
-    "version": "5.3.0",
+    "version": "6.0.0",
     "author": "Secreto31126",
     "description": "A TypeScript server agnostic Whatsapp's Official API framework",
     "license": "MIT",

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -45,19 +45,19 @@ export type OnSentArgs = {
      */
     request: ClientMessageRequest;
     /**
-     * The message id, undefined if parsed is set to false
+     * The message id
      */
     id?: string;
     /**
      * If true, the message send was delayed until quality can be validated and it will
-     * either be sent or dropped at this point. Undefined if parsed is set to false or
-     * the message_status property is not present in the response.
+     * either be sent or dropped at this point. Undefined if the message_status property
+     * is not present in the response.
      */
     held_for_quality_assessment?: boolean;
     /**
-     * The parsed response from the server, undefined if parsed is set to false
+     * The response from the server
      */
-    response?: ServerMessageResponse;
+    response: ServerMessageResponse;
     /**
      * Utility function for offloading code from the main thread,
      * useful for long running tasks such as AI generation

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ import type {
 } from "./messages/index.d.ts";
 import type { AtLeastOne } from "./utils.d.ts";
 
-export const DEFAULT_API_VERSION = "v22.0";
+export const DEFAULT_API_VERSION = "v24.0";
 
 /**
  * The main constructor arguments for the API

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,11 +79,6 @@ export type TheBasicConstructorArguments = {
      */
     v?: string;
     /**
-     * Whether to return a pre-processed response from the API or the raw fetch response.
-     * Intended for low level debugging.
-     */
-    parsed?: boolean;
-    /**
      * If set to false, none of the API checks will be performed, and it will be used in a less secure way.
      *
      * Defaults to true.

--- a/src/types.ts
+++ b/src/types.ts
@@ -749,12 +749,16 @@ export type ServerInitiation =
 export type ServerStatus = "sent" | "delivered" | "read" | "failed";
 
 export type ServerPricing = {
-    pricing_model: "CBP";
+    pricing_model: "PMP";
     /**
      * @deprecated Since v16 with the release of the new pricing model
      */
     billable?: boolean;
-    category: ServerInitiation | "authentication-international";
+    type: "regular" | "free_customer_service" | "free_entry_point";
+    category:
+        | ServerInitiation
+        | "authentication_international"
+        | "marketing_lite";
 };
 
 export type ServerConversation = {
@@ -806,7 +810,7 @@ export type PostData = {
                               biz_opaque_callback_data?: string;
                           } & (
                               | {
-                                    conversation: ServerConversation;
+                                    conversation?: ServerConversation;
                                     pricing: ServerPricing;
                                     errors: undefined;
                                 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -282,33 +282,6 @@ describe("WhatsAppAPI", () => {
             });
         });
 
-        it("should run the logger with id and response as undefined if parsed is set to false", async () => {
-            Whatsapp.parsed = false;
-
-            clientFacebook
-                .intercept({
-                    path: `/${Whatsapp.v}/${bot}/messages`,
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`
-                    }
-                })
-                .reply(200, expectedResponse)
-                .times(1);
-
-            Whatsapp.sendMessage(bot, user, message);
-
-            // Callbacks are executed in the next tick
-            await new Promise((resolve) => setTimeout(resolve, 0));
-
-            sinon_assert.calledOnceWithMatch(spy_on_sent, {
-                phoneID: bot,
-                to: user,
-                message: apiValidMessage,
-                request
-            });
-        });
-
         it("should not block the main thread with the user's callback", async () => {
             // Emulates a blocking function
             function block(delay) {
@@ -401,10 +374,6 @@ describe("WhatsAppAPI", () => {
                 fetch: undici_fetch,
                 subtle
             }
-        });
-
-        beforeEach(() => {
-            Whatsapp.parsed = true;
         });
 
         describe("Send", () => {
@@ -587,10 +556,6 @@ describe("WhatsAppAPI", () => {
                 fetch: undici_fetch,
                 subtle
             }
-        });
-
-        beforeEach(() => {
-            Whatsapp.parsed = true;
         });
 
         describe("Create", () => {
@@ -816,7 +781,6 @@ describe("WhatsAppAPI", () => {
 
         let form;
         beforeEach(() => {
-            Whatsapp.parsed = true;
             form = new FormData();
         });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -176,49 +176,6 @@ describe("WhatsAppAPI", () => {
         });
     });
 
-    describe("Parsed", () => {
-        it("should set parsed to true by default", () => {
-            const Whatsapp = new WhatsAppAPI({
-                v,
-                token,
-                appSecret,
-                ponyfill: {
-                    fetch: undici_fetch,
-                    subtle
-                }
-            });
-            equal(Whatsapp.parsed, true);
-        });
-
-        it("should be able to set parsed to true", () => {
-            const Whatsapp = new WhatsAppAPI({
-                v,
-                token,
-                appSecret,
-                parsed: true,
-                ponyfill: {
-                    fetch: undici_fetch,
-                    subtle
-                }
-            });
-            equal(Whatsapp.parsed, true);
-        });
-
-        it("should be able to set parsed to false", () => {
-            const Whatsapp = new WhatsAppAPI({
-                v,
-                token,
-                appSecret,
-                parsed: false,
-                ponyfill: {
-                    fetch: undici_fetch,
-                    subtle
-                }
-            });
-            equal(Whatsapp.parsed, false);
-        });
-    });
-
     describe("Logger", () => {
         const bot = "1";
         const user = "2";
@@ -518,29 +475,6 @@ describe("WhatsAppAPI", () => {
 
                 deepEqual(response, expectedResponse);
             });
-
-            it("should return the raw fetch response if parsed is false", async () => {
-                Whatsapp.parsed = false;
-
-                clientFacebook
-                    .intercept({
-                        path: `/${Whatsapp.v}/${bot}/messages`,
-                        method: "POST",
-                        headers: {
-                            Authorization: `Bearer ${token}`,
-                            "Content-Type": "application/json"
-                        },
-                        body: JSON.stringify(request)
-                    })
-                    .reply(200, expectedResponse)
-                    .times(1);
-
-                const response = await (
-                    await Whatsapp.sendMessage(bot, user, message)
-                ).json();
-
-                deepEqual(response, expectedResponse);
-            });
         });
 
         describe("Broadcast", () => {
@@ -600,37 +534,6 @@ describe("WhatsAppAPI", () => {
                 deepEqual(response, expectedArrayResponse);
             });
 
-            it("should return the raw fetch responses if parsed is false", async () => {
-                Whatsapp.parsed = false;
-
-                clientFacebook
-                    .intercept({
-                        path: `/${Whatsapp.v}/${bot}/messages`,
-                        method: "POST",
-                        headers: {
-                            Authorization: `Bearer ${token}`,
-                            "Content-Type": "application/json"
-                        },
-                        body: JSON.stringify(request)
-                    })
-                    .reply(200, expectedResponse)
-                    .times(3);
-
-                const response = await Promise.all(
-                    (
-                        await Promise.all(
-                            await Whatsapp.broadcastMessage(
-                                bot,
-                                [user, user, user],
-                                message
-                            )
-                        )
-                    ).map((e) => e.json())
-                );
-
-                deepEqual(response, expectedArrayResponse);
-            });
-
             it("should fail if batch_size or delay aren't valid", () => {
                 throws(() =>
                     Whatsapp.broadcastMessage(bot, [user], message, 0)
@@ -665,31 +568,6 @@ describe("WhatsAppAPI", () => {
                     .times(1);
 
                 const response = await Whatsapp.markAsRead(bot, id);
-
-                deepEqual(response, expectedResponse);
-            });
-
-            it("should return the raw fetch response if parsed is false", async () => {
-                Whatsapp.parsed = false;
-
-                const expectedResponse = {
-                    success: true
-                };
-
-                clientFacebook
-                    .intercept({
-                        path: `/${Whatsapp.v}/${bot}/messages`,
-                        method: "POST",
-                        headers: {
-                            Authorization: `Bearer ${token}`
-                        }
-                    })
-                    .reply(200, expectedResponse)
-                    .times(1);
-
-                const response = await (
-                    await Whatsapp.markAsRead(bot, id)
-                ).json();
 
                 deepEqual(response, expectedResponse);
             });
@@ -808,41 +686,6 @@ describe("WhatsAppAPI", () => {
 
                 deepEqual(response, expectedResponse);
             });
-
-            it("should return the raw fetch response if parsed is false", async () => {
-                Whatsapp.parsed = false;
-
-                const format = "png";
-
-                const expectedResponse = {
-                    code,
-                    prefilled_message: message,
-                    deep_link_url: `https://wa.me/message/${code}`,
-                    qr_image_url:
-                        "https://scontent.faep22-1.fna.fbcdn.net/m1/v/t6/another_weird_url"
-                };
-
-                clientFacebook
-                    .intercept({
-                        path: `/${Whatsapp.v}/${bot}/message_qrdls`,
-                        method: "POST",
-                        headers: {
-                            Authorization: `Bearer ${token}`
-                        },
-                        query: {
-                            generate_qr_image: format,
-                            prefilled_message: message
-                        }
-                    })
-                    .reply(200, expectedResponse)
-                    .times(1);
-
-                const response = await (
-                    await Whatsapp.createQR(bot, message)
-                ).json();
-
-                deepEqual(response, expectedResponse);
-            });
         });
 
         describe("Retrieve", () => {
@@ -897,34 +740,6 @@ describe("WhatsAppAPI", () => {
 
                 deepEqual(response, expectedResponse);
             });
-
-            it("should return the raw fetch response if parsed is false", async () => {
-                Whatsapp.parsed = false;
-
-                const expectedResponse = {
-                    data: [
-                        {
-                            code,
-                            prefilled_message: message,
-                            deep_link_url: `https://wa.me/message/${code}`
-                        }
-                    ]
-                };
-
-                clientFacebook
-                    .intercept({
-                        path: `/${Whatsapp.v}/${bot}/message_qrdls/`,
-                        headers: {
-                            Authorization: `Bearer ${token}`
-                        }
-                    })
-                    .reply(200, expectedResponse)
-                    .times(1);
-
-                const response = await (await Whatsapp.retrieveQR(bot)).json();
-
-                deepEqual(response, expectedResponse);
-            });
         });
 
         describe("Update", () => {
@@ -959,36 +774,6 @@ describe("WhatsAppAPI", () => {
 
                 deepEqual(response, expectedResponse);
             });
-
-            it("should return the raw fetch response if parsed is false", async () => {
-                Whatsapp.parsed = false;
-
-                const expectedResponse = {
-                    code,
-                    prefilled_message: new_message,
-                    deep_link_url: `https://wa.me/message/${code}`
-                };
-
-                clientFacebook
-                    .intercept({
-                        path: `/${Whatsapp.v}/${bot}/message_qrdls/${code}`,
-                        method: "POST",
-                        headers: {
-                            Authorization: `Bearer ${token}`
-                        },
-                        query: {
-                            prefilled_message: new_message
-                        }
-                    })
-                    .reply(200, expectedResponse)
-                    .times(1);
-
-                const response = await (
-                    await Whatsapp.updateQR(bot, code, new_message)
-                ).json();
-
-                deepEqual(response, expectedResponse);
-            });
         });
 
         describe("Delete", () => {
@@ -1009,31 +794,6 @@ describe("WhatsAppAPI", () => {
                     .times(1);
 
                 const response = await Whatsapp.deleteQR(bot, code);
-
-                deepEqual(response, expectedResponse);
-            });
-
-            it("should return the raw fetch response if parsed is false", async () => {
-                Whatsapp.parsed = false;
-
-                const expectedResponse = {
-                    success: true
-                };
-
-                clientFacebook
-                    .intercept({
-                        path: `/${Whatsapp.v}/${bot}/message_qrdls/${code}`,
-                        method: "DELETE",
-                        headers: {
-                            Authorization: `Bearer ${token}`
-                        }
-                    })
-                    .reply(200, expectedResponse)
-                    .times(1);
-
-                const response = await (
-                    await Whatsapp.deleteQR(bot, code)
-                ).json();
 
                 deepEqual(response, expectedResponse);
             });
@@ -1241,37 +1001,6 @@ describe("WhatsAppAPI", () => {
                     await Whatsapp.uploadMedia(bot, form, false);
                 });
             });
-
-            it("should return the raw fetch response if parsed is false", async () => {
-                Whatsapp.parsed = false;
-
-                const expectedResponse = { id };
-
-                form.append(
-                    "file",
-                    new Blob(["Hello World"], { type: "text/plain" })
-                );
-
-                clientFacebook
-                    .intercept({
-                        path: `/${Whatsapp.v}/${bot}/media`,
-                        method: "POST",
-                        headers: {
-                            Authorization: `Bearer ${token}`
-                        },
-                        query: {
-                            messaging_product: "whatsapp"
-                        }
-                    })
-                    .reply(200, expectedResponse)
-                    .times(1);
-
-                const response = await (
-                    await Whatsapp.uploadMedia(bot, form)
-                ).json();
-
-                deepEqual(response, expectedResponse);
-            });
         });
 
         describe("Retrieve", () => {
@@ -1327,35 +1056,6 @@ describe("WhatsAppAPI", () => {
 
                 deepEqual(response, expectedResponse);
             });
-
-            it("should return the raw fetch response if parsed is false", async () => {
-                Whatsapp.parsed = false;
-
-                const expectedResponse = {
-                    messaging_product: "whatsapp",
-                    url: "URL",
-                    mime_type: "image/jpeg",
-                    sha256: "HASH",
-                    file_size: "SIZE",
-                    id
-                };
-
-                clientFacebook
-                    .intercept({
-                        path: `/${Whatsapp.v}/${id}`,
-                        headers: {
-                            Authorization: `Bearer ${token}`
-                        }
-                    })
-                    .reply(200, expectedResponse)
-                    .times(1);
-
-                const response = await (
-                    await Whatsapp.retrieveMedia(id)
-                ).json();
-
-                deepEqual(response, expectedResponse);
-            });
         });
 
         describe("Delete", () => {
@@ -1400,29 +1100,6 @@ describe("WhatsAppAPI", () => {
                     .times(1);
 
                 const response = await Whatsapp.deleteMedia(id, bot);
-
-                deepEqual(response, expectedResponse);
-            });
-
-            it("should return the raw fetch response if parsed is false", async () => {
-                Whatsapp.parsed = false;
-
-                const expectedResponse = {
-                    success: true
-                };
-
-                clientFacebook
-                    .intercept({
-                        path: `/${Whatsapp.v}/${id}`,
-                        method: "DELETE",
-                        headers: {
-                            Authorization: `Bearer ${token}`
-                        }
-                    })
-                    .reply(200, expectedResponse)
-                    .times(1);
-
-                const response = await (await Whatsapp.deleteMedia(id)).json();
 
                 deepEqual(response, expectedResponse);
             });


### PR DESCRIPTION
This is a kinda small major update. With the new per-message pricing model, some types needed breaking changes, so I took the oportunity to remove the disgusting "feature" that was `parsed`.

Should this have been 2 or 3 PRs? Maybe. But most of the line changes are from removing unit tests :]

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `npm run test` and lint the project with `npm run lint` and `npm run prettier`
