### PR TITLE
Fix sdp_type on pre_accept and accept call actions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1181,8 +1181,7 @@ export class WhatsAppAPI<EmittersReturnType = void>
      */
     private static toRecipient<
         T extends
-            | ClientRecipientIdentifier
-            | ClientIndividualRecipientIdentifier
+            ClientRecipientIdentifier | ClientIndividualRecipientIdentifier
     >(r: string | T): T;
 
     /**
@@ -1190,8 +1189,7 @@ export class WhatsAppAPI<EmittersReturnType = void>
      */
     private static toRecipient<
         T extends
-            | ClientRecipientIdentifier
-            | ClientIndividualRecipientIdentifier
+            ClientRecipientIdentifier | ClientIndividualRecipientIdentifier
     >(r: string[] | T[]): T[];
 
     /**
@@ -1201,8 +1199,7 @@ export class WhatsAppAPI<EmittersReturnType = void>
      */
     private static toRecipient<
         T extends
-            | ClientRecipientIdentifier
-            | ClientIndividualRecipientIdentifier
+            ClientRecipientIdentifier | ClientIndividualRecipientIdentifier
     >(r: string | T | string[] | T[]) {
         if (Array.isArray(r)) return r.map(WhatsAppAPI.toRecipient);
         if (typeof r !== "string") return r;

--- a/src/index.ts
+++ b/src/index.ts
@@ -515,7 +515,7 @@ export class WhatsAppAPI<EmittersReturnType = void>
                     call_id: callID,
                     action: "pre_accept",
                     session: {
-                        sdp_type: "offer",
+                        sdp_type: "answer",
                         sdp
                     }
                 })
@@ -563,7 +563,7 @@ export class WhatsAppAPI<EmittersReturnType = void>
                     action: "accept",
                     biz_opaque_callback_data,
                     session: {
-                        sdp_type: "offer",
+                        sdp_type: "answer",
                         sdp
                     }
                 })

--- a/src/messages/template.ts
+++ b/src/messages/template.ts
@@ -296,12 +296,7 @@ export abstract class ButtonComponent implements TemplateComponent {
      * The subtype of the component
      */
     readonly sub_type:
-        | "url"
-        | "quick_reply"
-        | "catalog"
-        | "mpm"
-        | "copy_code"
-        | "flow";
+        "url" | "quick_reply" | "catalog" | "mpm" | "copy_code" | "flow";
     /**
      * The parameter of the component
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,8 +172,7 @@ export type ClientGroupRecipientIdentifier = {
 };
 
 export type ClientRecipientIdentifier =
-    | ClientIndividualRecipientIdentifier
-    | ClientGroupRecipientIdentifier;
+    ClientIndividualRecipientIdentifier | ClientGroupRecipientIdentifier;
 
 /**
  * The base class of all the library messages
@@ -1008,9 +1007,7 @@ export type ServerPricing = {
     billable?: boolean;
     type: "regular" | "free_customer_service" | "free_entry_point";
     category:
-        | ServerInitiation
-        | "authentication_international"
-        | "marketing_lite";
+        ServerInitiation | "authentication_international" | "marketing_lite";
 };
 
 export type ServerConversation = {
@@ -1040,8 +1037,7 @@ export type GetParams = {
 export type PostDataMessageField = {
     field: "messages";
     value: { contacts?: [ServerContacts] } & (
-        | { messages: [ServerMessage] }
-        | { statuses: [ServerStatusPayload] }
+        { messages: [ServerMessage] } | { statuses: [ServerStatusPayload] }
     );
 };
 
@@ -1137,12 +1133,10 @@ export type ServerSentMessageResponse = {
 };
 
 export type ServerMessageResponse =
-    | (ServerSentMessageResponse & NoServerError)
-    | ServerErrorResponse;
+    (ServerSentMessageResponse & NoServerError) | ServerErrorResponse;
 
 export type ServerMarkAsReadResponse =
-    | ServerSuccessResponse
-    | ServerErrorResponse;
+    ServerSuccessResponse | ServerErrorResponse;
 
 export type ServerInitiateCallResponse =
     | {
@@ -1175,28 +1169,23 @@ export type ServerQR = {
 };
 
 export type ServerCreateQRResponse =
-    | (ServerQR & NoServerError)
-    | ServerErrorResponse;
+    (ServerQR & NoServerError) | ServerErrorResponse;
 
 export type ServerRetrieveQRResponse =
-    | ({ data: ServerQR[] } & NoServerError)
-    | ServerErrorResponse;
+    ({ data: ServerQR[] } & NoServerError) | ServerErrorResponse;
 
 export type ServerUpdateQRResponse =
-    | (ServerQR & NoServerError)
-    | ServerErrorResponse;
+    (ServerQR & NoServerError) | ServerErrorResponse;
 
 export type ServerDeleteQRResponse =
-    | ServerSuccessResponse
-    | ServerErrorResponse;
+    ServerSuccessResponse | ServerErrorResponse;
 
 export type ServerMedia = {
     id: string;
 };
 
 export type ServerMediaUploadResponse =
-    | (ServerMedia & NoServerError)
-    | ServerErrorResponse;
+    (ServerMedia & NoServerError) | ServerErrorResponse;
 
 export type ValidMimeTypes =
     | "audio/aac"
@@ -1230,8 +1219,7 @@ export type ServerMediaRetrieveResponse =
     | ServerErrorResponse;
 
 export type ServerMediaDeleteResponse =
-    | ServerSuccessResponse
-    | ServerErrorResponse;
+    ServerSuccessResponse | ServerErrorResponse;
 
 export type ServerBlockedError = Pick<
     ServerErrorResponse["error"],


### PR DESCRIPTION
## Motivation

When a user calls the business, `preacceptCall` and `acceptCall` respond to the caller's SDP offer. Both methods currently send `sdp_type: "offer"` in the payload, so the call never connects: the Cloud API expects the business side to reply with an answer, not another offer.

The Meta documentation for user-initiated calls shows `"sdp_type": "answer"` in the request examples for both actions:

- Pre-accept call: https://developers.facebook.com/docs/whatsapp/cloud-api/calling/user-initiated-calls#pre-accept-call
- Accept call: https://developers.facebook.com/docs/whatsapp/cloud-api/calling/user-initiated-calls#accept-call

We hit this in production while integrating calling and confirmed that switching the value to `"answer"` makes both actions work as expected.

## Solution

Send `sdp_type: "answer"` in `preacceptCall` and `acceptCall`. `initiateCall` keeps `"offer"`, which is correct since the business starts that call. The webhook types are untouched, as the incoming `connect` event really carries an offer.
